### PR TITLE
fix(everyone): Ignore if message tag everyone

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,7 +38,7 @@ async def on_message(message:discord.Message):
 	if message.author == bot.user:
 		return
 	# Ignore messages sent to everyone
-	if '@everyone' in message.content:
+	if message.mention_everyone:
 		return
 	# Check if the bot is mentioned or the message is a DM
 	if not (bot.user.mentioned_in(message) or isinstance(message.channel, discord.DMChannel) or message.channel.id in tracked_channels or message.channel.id in tracked_threads):

--- a/bot.py
+++ b/bot.py
@@ -37,6 +37,9 @@ async def on_message(message:discord.Message):
 	# Ignore messages sent by the bot
 	if message.author == bot.user:
 		return
+	# Ignore messages sent to everyone
+	if '@everyone' in message.content:
+		return
 	# Check if the bot is mentioned or the message is a DM
 	if not (bot.user.mentioned_in(message) or isinstance(message.channel, discord.DMChannel) or message.channel.id in tracked_channels or message.channel.id in tracked_threads):
 		return


### PR DESCRIPTION
I am very happy using the Discord bot you made.

When using @everyone to tag everyone in a Discord channel, it has been inconvenient because Gemini sometimes responds. Therefore, I am requesting a pull request.